### PR TITLE
Changes for aligning with UDP export

### DIFF
--- a/src/grpc/lib-oc/OpenConfigCpuMemoryUtilization.cpp
+++ b/src/grpc/lib-oc/OpenConfigCpuMemoryUtilization.cpp
@@ -24,14 +24,18 @@ OpenConfigCpuMemoryUtilization::iterate (JuniperNetworksSensors *handle, Telemet
 
     for (int i = 0; i < message->utilization_size(); i++) {
         const CpuMemoryUtilizationSummary& summary = message->utilization(i);
-        
+       
+        if (!summary.bytes_allocated()) {
+            continue;
+        }
+ 
         kv = datap->add_kv();
         kv->set_key(summary.name() + "/size");
-        kv->set_int_value(summary.size());
+        kv->set_uint_value(summary.size());
         
         kv = datap->add_kv();
         kv->set_key(summary.name() + "/bytes_allocated");
-        kv->set_int_value(summary.bytes_allocated());
+        kv->set_uint_value(summary.bytes_allocated());
         
         kv = datap->add_kv();
         kv->set_key(summary.name() + "/utilization");
@@ -46,19 +50,19 @@ OpenConfigCpuMemoryUtilization::iterate (JuniperNetworksSensors *handle, Telemet
 
             kv = datap->add_kv();
             kv->set_key(summary.name() + "/applications/" + app.name() + "/bytes_allocated");
-            kv->set_int_value(app.bytes_allocated());
+            kv->set_uint_value(app.bytes_allocated());
             
             kv = datap->add_kv();
             kv->set_key(summary.name() + "/applications/" + app.name() + "/allocations");
-            kv->set_int_value(app.allocations());
+            kv->set_uint_value(app.allocations());
 
             kv = datap->add_kv();
             kv->set_key(summary.name() + "/applications/" + app.name() + "/frees");
-            kv->set_int_value(app.frees());
+            kv->set_uint_value(app.frees());
             
             kv = datap->add_kv();
             kv->set_key(summary.name() + "/applications/" + app.name() + "/allocations_failed");
-            kv->set_int_value(app.allocations_failed());
+            kv->set_uint_value(app.allocations_failed());
         }
     }
 }

--- a/src/grpc/lib-oc/OpenConfigNpuMem.cpp
+++ b/src/grpc/lib-oc/OpenConfigNpuMem.cpp
@@ -24,21 +24,21 @@ OpenConfigNpuMem::iterate (JuniperNetworksSensors *handle, Telemetry::OpenConfig
         for (int j = 0; j < message->memory_stats(i).summary_size(); j++) {
             const NpuMemorySummary &summary = message->memory_stats(i).summary(j);
             
+            if (!summary.allocated()) {
+                continue;
+            }
+
             kv = datap->add_kv();
             kv->set_key("summary/" + summary.resource_name() + "/size");
-            kv->set_int_value(summary.size());
+            kv->set_uint_value(summary.size());
             
-            if (summary.allocated()) {
-                kv = datap->add_kv();
-                kv->set_key("summary/" + summary.resource_name() + "/allocated");
-                kv->set_int_value(summary.allocated());
-            }
+            kv = datap->add_kv();
+            kv->set_key("summary/" + summary.resource_name() + "/allocated");
+            kv->set_uint_value(summary.allocated());
             
-            if (summary.utilization()) {
-                kv = datap->add_kv();
-                kv->set_key("summary/" + summary.resource_name() + "/utilization");
-                kv->set_int_value(summary.utilization());
-            }
+            kv = datap->add_kv();
+            kv->set_key("summary/" + summary.resource_name() + "/utilization");
+            kv->set_int_value(summary.utilization());
         }
         
         for (int j = 0; j < message->memory_stats(i).partition_size(); j++) {

--- a/src/grpc/lib-oc/OpenConfigNpuUtilization.cpp
+++ b/src/grpc/lib-oc/OpenConfigNpuUtilization.cpp
@@ -41,25 +41,19 @@ OpenConfigNpuUtilization::iterate (JuniperNetworksSensors *handle, Telemetry::Op
 
             kv = datap->add_kv();
             kv->set_key("memory/" + mem.name() + "/lowest_util");
-            kv->set_int_value(mem.highest_util());
+            kv->set_int_value(mem.lowest_util());
 
-            if (mem.average_cache_hit_rate()) {
-                kv = datap->add_kv();
-                kv->set_key("memory/" + mem.name() + "/average_cache_hit_rate");
-                kv->set_int_value(mem.average_cache_hit_rate());
-            }
+            kv = datap->add_kv();
+            kv->set_key("memory/" + mem.name() + "/average_cache_hit_rate");
+            kv->set_int_value(mem.average_cache_hit_rate());
 
-            if (mem.highest_cache_hit_rate()) {
-                kv = datap->add_kv();
-                kv->set_key("memory/" + mem.name() + "/highest_cache_hit_rate");
-                kv->set_int_value(mem.highest_cache_hit_rate());
-            }
+            kv = datap->add_kv();
+            kv->set_key("memory/" + mem.name() + "/highest_cache_hit_rate");
+            kv->set_int_value(mem.highest_cache_hit_rate());
 
-            if (mem.lowest_cache_hit_rate()) {
-                kv = datap->add_kv();
-                kv->set_key("memory/" + mem.name() + "/lowest_cache_hit_rate");
-                kv->set_int_value(mem.lowest_cache_hit_rate());
-            }
+            kv = datap->add_kv();
+            kv->set_key("memory/" + mem.name() + "/lowest_cache_hit_rate");
+            kv->set_int_value(mem.lowest_cache_hit_rate());
         }
 
         for (int j = 0; j < util.packets_size(); j++) {
@@ -71,7 +65,7 @@ OpenConfigNpuUtilization::iterate (JuniperNetworksSensors *handle, Telemetry::Op
 
             kv = datap->add_kv();
             kv->set_key("packet/" + packet.identifier() + "/rate");
-            kv->set_int_value(packet.rate());
+            kv->set_uint_value(packet.rate());
         }
     }
 }


### PR DESCRIPTION
This diff includes the following changes,
1) Converted int64 to uint64 wherever required based on the description in the respective proto files.
2) Skip export of records which have allocations as zero.
3) Corrected export of lowest npu memory utilization.
