### PR TITLE
gRPC 1.0.0 updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,26 +4,28 @@ MAINTAINER Surya Nimmagadda <nscsekhar@juniper.net> && Abbas Sakarwala <abbas@ju
 # Install base packages
 RUN cd /home  \
 && sudo apt-get update \
-&& sudo apt-get install -y git wget curl zip unzip \
+&& sudo apt-get install -y git wget curl zip unzip pkg-config \
 && sudo apt-get install -y build-essential autoconf libtool \
 && apt-get install -y python \
-&& apt-get install -y python-setuptools
+&& apt-get install -y python-setuptools python-pip
 
-# Install GRPC and GPB
+# install relevant gRPC tools
 RUN cd /home \
-&& git clone -b release-0_11 https://github.com/grpc/grpc grpc \
-&& cd /home/grpc \
+&& git clone https://github.com/grpc/grpc grpc \
+&& cd /home/grpc  \
 && git submodule update --init \
 && make \
-&& make install \
-&& cd /home/grpc/third_party/protobuf/  \
+&& sudo make install \
+&& cd /home/grpc/third_party/protobuf/ \
 &&  ./autogen.sh \
 &&  ./configure \
-&&  sudo make \
-&&  sudo make install \
-&& cd /home/grpc/third_party/protobuf/python \
-&&  python setup.py build \
-&&  python setup.py install
+&& make \
+&& sudo make install
+
+# install python bindings
+RUN sudo python -m pip install --upgrade pip \
+&&  sudo python -m pip install grpcio \
+&&  sudo python -m pip install grpcio-tools 
 
 # Install mosquitto
 RUN cd /home \
@@ -33,7 +35,6 @@ RUN cd /home \
 && cd mosquitto-1.3.5 \
 && cmake . \
 && sudo make install \
-&& apt-get install -y python-pip \
 && pip install paho-mqtt \
 && useradd mosquitto
 

--- a/src/grpc/client/AgentClient.cpp
+++ b/src/grpc/client/AgentClient.cpp
@@ -61,7 +61,7 @@ void
 AgentClient::rehome (void)
 {
     stub_ = OpenConfigTelemetry::NewStub(grpc::CreateChannel(AGENT_SERVER_IP_PORT,
-                                         grpc::InsecureCredentials()));
+                                         grpc::InsecureChannelCredentials()));
 }
 
 AgentClient *

--- a/src/grpc/client/AgentClientParser.cpp
+++ b/src/grpc/client/AgentClientParser.cpp
@@ -38,7 +38,7 @@ handle_subscribe (int argc, const char *argv[])
 
     // Create a client
     client = AgentClient::create(grpc::CreateChannel(AGENT_SERVER_IP_PORT,
-                                 grpc::InsecureCredentials()),
+                                 grpc::InsecureChannelCredentials()),
                                  client_name,
                                  global_id++,
                                  parser->getLogDir());
@@ -71,7 +71,7 @@ handle_subscribe_telegraf (int argc, const char *argv[])
 
     // Create a client
     client = AgentClient::create(grpc::CreateChannel(AGENT_SERVER_IP_PORT,
-                                 grpc::InsecureCredentials()),
+                                 grpc::InsecureChannelCredentials()),
                                  client_name,
                                  global_id++,
                                  parser->getLogDir());
@@ -104,7 +104,7 @@ handle_subscribe_limits (int argc, const char *argv[])
 
     // Create a client
     client = AgentClient::create(grpc::CreateChannel(AGENT_SERVER_IP_PORT,
-                                 grpc::InsecureCredentials()),
+                                 grpc::InsecureChannelCredentials()),
                                  client_name,
                                  global_id++,
                                  parser->getLogDir());
@@ -143,7 +143,7 @@ proc (void *args)
 
     // Create a client
     client = AgentClient::create(grpc::CreateChannel(AGENT_SERVER_IP_PORT,
-                                 grpc::InsecureCredentials()),
+                                 grpc::InsecureChannelCredentials()),
                                  client_name,
                                  global_id++,
                                  parser->getLogDir());

--- a/src/grpc/client/main.cpp
+++ b/src/grpc/client/main.cpp
@@ -52,7 +52,7 @@ int main(int argc, const char * argv[])
     // A well known Management Client
     std::string mgmt_client_name(AGENTCLIENT_MGMT);
     AgentClient::create(grpc::CreateChannel(AGENT_SERVER_IP_PORT,
-                        grpc::InsecureCredentials()),
+                        grpc::InsecureChannelCredentials()),
                         mgmt_client_name,
                         global_id++,
                         logfile_dir);

--- a/src/grpc/server/AgentRestart.cpp
+++ b/src/grpc/server/AgentRestart.cpp
@@ -112,7 +112,7 @@ _jsd_register (AgentServerLog *_logger, Json::Value &registration_obj)
     }
     std::shared_ptr<grpc::Channel> channel = grpc::CreateChannel(
                                                 jsd_address,
-                                                grpc::InsecureCredentials());
+                                                grpc::InsecureChannelCredentials());
 
     // Off-box mode requires login authentication
     if (global_config.running_mode == RUNNING_MODE_OFF_BOX) {

--- a/src/grpc/server/AgentSystemProc.cpp
+++ b/src/grpc/server/AgentSystemProc.cpp
@@ -35,7 +35,7 @@ AgentSystemProc::_sendOCMessagetoMgd (std::string &config,
                             std::to_string(global_config.device_mgd_port));
     std::shared_ptr<grpc::Channel> channel = grpc::CreateChannel(
                                                  mgd_address,
-                                                 grpc::InsecureCredentials());
+                                                 grpc::InsecureChannelCredentials());
     stub_ = OpenconfigRpcApi::NewStub(channel);
 
     // Form the mgd request
@@ -139,7 +139,7 @@ AgentSystemProc::_sendJunosMessagetoMgd (std::string &config,
     }
     std::shared_ptr<grpc::Channel> channel = grpc::CreateChannel(
                                                    mgd_address,
-                                                   grpc::InsecureCredentials());
+                                                   grpc::InsecureChannelCredentials());
 
     // Off-box mode requires login authentication
     if (global_config.running_mode == RUNNING_MODE_OFF_BOX) {
@@ -343,7 +343,7 @@ AgentSystemProc::systemGet (SystemId id)
     }
     std::shared_ptr<grpc::Channel> channel = grpc::CreateChannel(
                                                 mgd_address,
-                                                grpc::InsecureCredentials());
+                                                grpc::InsecureChannelCredentials());
     stub_ = ManagementRpcApi::NewStub(channel);
 
 #if defined(__OC_Telemetry_Config__)

--- a/src/grpc/test/agent_test.cpp
+++ b/src/grpc/test/agent_test.cpp
@@ -21,7 +21,7 @@ TEST_F(AgentClientTest, subscribe_and_force_terminate) {
     // Create the test client
     std::string mgmt_client_name(AGENTCLIENT_MGMT);
     client = AgentClient::create(grpc::CreateChannel(GRPC_SERVER_IP_PORT,
-                                 grpc::InsecureCredentials()),
+                                 grpc::InsecureChannelCredentials()),
                                  mgmt_client_name, 0, CLIENT_LOGDIR);
     EXPECT_TRUE(client != NULL);
     if (!client) {
@@ -97,7 +97,7 @@ TEST_F(AgentClientTest, subscribe_and_graceful_terminate) {
     // Create the test client
     std::string mgmt_client_name(AGENTCLIENT_MGMT);
     client = AgentClient::create(grpc::CreateChannel(GRPC_SERVER_IP_PORT,
-                                 grpc::InsecureCredentials()),
+                                 grpc::InsecureChannelCredentials()),
                                  mgmt_client_name, 0, CLIENT_LOGDIR);
     EXPECT_TRUE(client != NULL);
     if (!client) {
@@ -161,7 +161,7 @@ TEST_F(AgentClientTest, list) {
     // Create the test client
     std::string mgmt_client_name(AGENTCLIENT_MGMT);
     client = AgentClient::create(grpc::CreateChannel(GRPC_SERVER_IP_PORT,
-                                 grpc::InsecureCredentials()),
+                                 grpc::InsecureChannelCredentials()),
                                  mgmt_client_name, 0, CLIENT_LOGDIR);
     EXPECT_TRUE(client != NULL);
     if (!client) {
@@ -249,7 +249,7 @@ TEST_F(AgentClientTest, multiple_subscribe) {
     // Create the test client
     std::string mgmt_client_name(AGENTCLIENT_MGMT);
     mgmt_client = AgentClient::create(grpc::CreateChannel(GRPC_SERVER_IP_PORT,
-                                      grpc::InsecureCredentials()),
+                                      grpc::InsecureChannelCredentials()),
                                       mgmt_client_name, 0, CLIENT_LOGDIR);
     EXPECT_TRUE(mgmt_client != NULL);
     if (!mgmt_client) {
@@ -302,7 +302,7 @@ TEST_F(AgentClientTest, verify_multiple_subscribe) {
     // Create the test client
     std::string mgmt_client_name(AGENTCLIENT_MGMT);
     mgmt_client = AgentClient::create(grpc::CreateChannel(GRPC_SERVER_IP_PORT,
-                                      grpc::InsecureCredentials()),
+                                      grpc::InsecureChannelCredentials()),
                                       mgmt_client_name, 0, CLIENT_LOGDIR);
     EXPECT_TRUE(mgmt_client != NULL);
     if (!mgmt_client) {
@@ -388,7 +388,7 @@ TEST_F(AgentClientTest, get_oper_all) {
     // Create the test client
     std::string mgmt_client_name(AGENTCLIENT_MGMT);
     mgmt_client = AgentClient::create(grpc::CreateChannel(GRPC_SERVER_IP_PORT,
-                                      grpc::InsecureCredentials()),
+                                      grpc::InsecureChannelCredentials()),
                                       mgmt_client_name, 0, CLIENT_LOGDIR);
     EXPECT_TRUE(mgmt_client != NULL);
     if (!mgmt_client) {
@@ -495,7 +495,7 @@ TEST_F(AgentClientTest, subscribe_and_path_validation_2v_1inv) {
     // Create the test client
     std::string mgmt_client_name(AGENTCLIENT_MGMT);
     client = AgentClient::create(grpc::CreateChannel(GRPC_SERVER_IP_PORT,
-                                 grpc::InsecureCredentials()),
+                                 grpc::InsecureChannelCredentials()),
                                  mgmt_client_name, 0, CLIENT_LOGDIR);
     EXPECT_TRUE(client != NULL);
     if (!client) {
@@ -575,7 +575,7 @@ TEST_F(AgentClientTest, subscribe_and_path_validation_Allinv) {
     // Create the test client
     std::string mgmt_client_name(AGENTCLIENT_MGMT);
     client = AgentClient::create(grpc::CreateChannel(GRPC_SERVER_IP_PORT,
-                                 grpc::InsecureCredentials()),
+                                 grpc::InsecureChannelCredentials()),
                                  mgmt_client_name, 0, CLIENT_LOGDIR);
     EXPECT_TRUE(client != NULL);
     if (!client) {
@@ -644,7 +644,7 @@ TEST_F(AgentClientTest, encoding) {
     // Create the test client
     std::string mgmt_client_name(AGENTCLIENT_MGMT);
     client = AgentClient::create(grpc::CreateChannel(GRPC_SERVER_IP_PORT,
-                                 grpc::InsecureCredentials()),
+                                 grpc::InsecureChannelCredentials()),
                                  mgmt_client_name, 0, CLIENT_LOGDIR);
     EXPECT_TRUE(client != NULL);
     if (!client) {
@@ -671,7 +671,7 @@ AgentClientTest::create_subscriptions (void *args)
     std::string client_name("client-" + std::to_string(test_args->index));
     client = AgentClient::create(grpc::CreateChannel(
                                    test_args->grpc_server_ip_port,
-                                   grpc::InsecureCredentials()),
+                                   grpc::InsecureChannelCredentials()),
                                  client_name, 0, test_args->client_logdir);
     EXPECT_TRUE(client != NULL);
     if (!client) {
@@ -808,7 +808,7 @@ TEST_F(AgentClientTest, stress_test_sub_unsub) {
         // Create the test client
         std::string client_name("stress_test");
         client = AgentClient::create(grpc::CreateChannel(grpc_server_ip_port,
-                                     grpc::InsecureCredentials()),
+                                     grpc::InsecureChannelCredentials()),
                                      client_name, 0, CLIENT_LOGDIR);
         EXPECT_TRUE(client != NULL);
         if (!client) {
@@ -892,7 +892,7 @@ TEST_F(AgentClientTest, stress_test_sub_unsub) {
     // Create the test client
     std::string mgmt_client_name(AGENTCLIENT_MGMT);
     mgmt_client = AgentClient::create(grpc::CreateChannel(grpc_server_ip_port,
-                                      grpc::InsecureCredentials()),
+                                      grpc::InsecureChannelCredentials()),
                                       mgmt_client_name, 0, CLIENT_LOGDIR);
     EXPECT_TRUE(mgmt_client != NULL);
     if (!mgmt_client) {

--- a/src/grpc/test/agent_test_oc.cpp
+++ b/src/grpc/test/agent_test_oc.cpp
@@ -21,7 +21,7 @@ TEST_F(AgentClientOpenConfigTest, oc_paths) {
     // Create the test client
     std::string mgmt_client_name(AGENTCLIENT_MGMT);
     client = AgentClient::create(grpc::CreateChannel(GRPC_SERVER_IP_PORT,
-                                                     grpc::InsecureCredentials()),
+                                                     grpc::InsecureChannelCredentials()),
                                  mgmt_client_name, 0, CLIENT_LOGDIR);
     EXPECT_TRUE(client != NULL);
     if (!client) {


### PR DESCRIPTION
updates the jvsim gRPC code and the Dockerfile to use v1.0.0 APIs.

note: this currently tracks against the HEAD of the gRPC repo, as the v1.0.0 branch has broken dependencies and will not build cleanly. (of note, the gmock dependencies are broken.) this may require attention in the future.